### PR TITLE
Nissix plugin scope-packages on fed-entry-level-exam-root

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,6 @@
     "react-scripts": "^3.1.2",
     "typescript": "3.5.3",
     "@fed-exam/config": "^1.0.0"
-
   },
   "scripts": {
     "start": "CI=true react-scripts start",

--- a/configuration/package.json
+++ b/configuration/package.json
@@ -2,12 +2,10 @@
   "name": "@fed-exam/config",
   "version": "1.0.0",
   "main": "index.ts",
-  "scripts": {
-  },
+  "scripts": {},
   "author": "",
   "license": "ISC",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {},
   "description": ""
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,26 +1,26 @@
 {
-	"name": "@fed-exam/server",
-	"version": "1.0.0",
-	"main": "index.js",
+  "name": "@fed-exam/server",
+  "version": "1.0.0",
+  "main": "index.js",
   "scripts": {
     "start": "ts-node-dev index.ts",
     "d": "ts-node index.ts"
   },
-	"author": "",
-	"license": "ISC",
-	"dependencies": {
-		"@fed-exam/config": "^1.0.0",
-		"@types/body-parser": "^1.17.1",
-		"@types/chance": "^1.0.6",
-		"@types/express": "^4.17.1",
-		"@types/node": "^12.7.2",
-		"body-parser": "^1.19.0",
-		"chance": "^1.1.0",
-		"express": "^4.17.1",
-		"googleapis": "^39.2.0",
-		"ts-node": "^8.3.0",
-		"typescript": "^3.5.3",
-		"ts-node-dev": "1.1.0"
-	},
-	"description": ""
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@fed-exam/config": "^1.0.0",
+    "@types/body-parser": "^1.17.1",
+    "@types/chance": "^1.0.6",
+    "@types/express": "^4.17.1",
+    "@types/node": "^12.7.2",
+    "body-parser": "^1.19.0",
+    "chance": "^1.1.0",
+    "express": "^4.17.1",
+    "googleapis": "^39.2.0",
+    "ts-node": "^8.3.0",
+    "typescript": "^3.5.3",
+    "ts-node-dev": "1.1.0"
+  },
+  "description": ""
 }


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 11.823s
sh: 1: lerna: not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! fed-entry-level-exam-root@1.0.0 bootstrap: `lerna bootstrap`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the fed-entry-level-exam-root@1.0.0 bootstrap script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/deployer/.npm/_logs/2021-03-02T13_56_39_009Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! fed-entry-level-exam-root@1.0.0 postinstall: `npm run bootstrap`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the fed-entry-level-exam-root@1.0.0 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/deployer/.npm/_logs/2021-03-02T13_56_39_037Z-debug.log
(node:8799) UnhandledPromiseRejectionWarning: Error: Command failed with exit code 1: npm i
    at makeError (/app/node_modules/execa/lib/error.js:59:11)
    at handlePromise (/app/node_modules/execa/index.js:114:26)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:8799) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:8799) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.



Output Log:
Migrating package "fed-entry-level-exam-root" in .


## Migration from non scope to @wix/scoped packages
> /tmp/c281cfaeab4feb5b8c052027f616a88d

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
client/package.json
configuration/package.json
server/package.json
```

> fed-entry-level-exam-root@1.0.0 postinstall /tmp/c281cfaeab4feb5b8c052027f616a88d
> npm run bootstrap


> fed-entry-level-exam-root@1.0.0 bootstrap /tmp/c281cfaeab4feb5b8c052027f616a88d
> lerna bootstrap


